### PR TITLE
fix windows build

### DIFF
--- a/core/deps/picotcp/stack/pico_socket.c
+++ b/core/deps/picotcp/stack/pico_socket.c
@@ -1091,10 +1091,11 @@ static int pico_socket_xmit_one(struct pico_socket *s, const void *buf, const in
     else if (IS_SOCK_IPV6(s) && ep && pico_ipv6_is_multicast(&ep->remote_addr.ip6.addr[0])) {
         dev = pico_ipv6_link_find(src);
     }
-#endif
     else if (IS_SOCK_IPV6(s) && ep) {
         dev = pico_ipv6_source_dev_find(&ep->remote_addr.ip6);
-    } else if (IS_SOCK_IPV4(s) && ep) {
+    }
+#endif
+    else if (IS_SOCK_IPV4(s) && ep) {
         dev = pico_ipv4_source_dev_find(&ep->remote_addr.ip4);
     } else {
         dev = get_sock_dev(s);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,6 +5,7 @@
     "angle",
     "sdl2",
     "zlib",
-    "asio"
+    "asio",
+    "openssl"
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,7 @@
   "dependencies": [
     "angle",
     "sdl2",
-    "zlib"
+    "zlib",
+    "asio"
   ]
 }


### PR DESCRIPTION
While trying to build this project on windows with MSVC and vcpkg, I ran into two problems:
* some code #includes asio headers, but asio isn't vendored in core/deps, pulled in via FetchContent, or vcpkg
* a linker error complaining about missing missing some picotcp ipv6 function, despite IPV6 support not being enabled. Looks like the callsite should have been guarded by a macro, but wasn't.

So I tried to fix these and got it building with VS 2019.