### PR TITLE
Add IsTraining for lua. Autoload Virtua Fighter 3tb training script

### DIFF
--- a/core/dojo/DojoSession.cpp
+++ b/core/dojo/DojoSession.cpp
@@ -998,6 +998,8 @@ std::string DojoSession::GetTrainingLua()
 			return get_readonly_data_path("training/mvsc2.lua");
 	else if (settings.content.gameId == "PAXTEZ_IP")
 			return get_readonly_data_path("training/mvsc2.lua");
+	else if (settings.content.gameId == "MK-51001")
+			return get_readonly_data_path("training/vf3.lua");
 	else
 	{
 		// look up by game file name in training folder

--- a/core/lua/lua.cpp
+++ b/core/lua/lua.cpp
@@ -673,6 +673,7 @@ static void luaRegister(lua_State *L)
 				.endNamespace()
 
 				.beginNamespace("dojo")
+					.addProperty("IsTraining", &settings.dojo.training, false)
 					CONFIG_PROPERTY(ShowTrainingGameOverlay, bool)
 				.endNamespace()
 			.endNamespace()


### PR DESCRIPTION
Expose training boolean value for Lua script. This can be helpful to hide cheat/training overlays when watching replays but still run the script for framedata. 

Autoload vf3tb script if found in the training folder.

PR for lua script: https://github.com/blueminder/flycast-dojo-training/pull/2